### PR TITLE
Report errors happened during hooks execution

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -7,6 +7,6 @@
         "quotes": [2, "double", {"avoidEscape": true}],
         "semi": 2,
         "one-var": [2, "never"],
-        "no-console": 1
+        "no-console": 0
     }
 }

--- a/test/unit/reporter.spec.js
+++ b/test/unit/reporter.spec.js
@@ -130,4 +130,19 @@ describe("Allure reporter", function() {
             done();
         });
     });
+
+    it("should report internal errors", function(done) {
+        sinon.stub(console, "error");
+        var mocha = new Mocha({
+            reporter: reporter
+        });
+        allureMock.endSuite.onCall(1).throws();
+        mocha.addFile(path.join(__dirname, "../fixtures/retries.spec.js"));
+        mocha.run(function() {
+            expect(console.error).callCount(1);
+            expect(console.error).calledWith("Internal error in Allure:", sinon.match.instanceOf(Error));
+            console.error.restore();
+            done();
+        });
+    });
 });


### PR DESCRIPTION
Mocha fails silently when some of lifecycle listeners has thrown an error. In order to provide better development experience we need to catch our internal errors and print them to console to make it easier to report bugs to us.

ref #30