### PR TITLE
add support for node 8, fix assertion error detection

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ env:
     - CXX=g++-4.8
   matrix:
     - TRAVIS_NODE_VERSION=6
-    - TRAVIS_NODE_VERSION=4
+    - TRAVIS_NODE_VERSION=8
 
 before_install:
   - nvm install $TRAVIS_NODE_VERSION

--- a/index.js
+++ b/index.js
@@ -58,7 +58,8 @@ function AllureReporter(runner, opts) {
         if(!allureReporter.getCurrentTest()) {
             allureReporter.startCase(test.title);
         }
-        var status = err.name === "AssertionError" ? "failed" : "broken";
+        var isAssertionError = err.name === "AssertionError" || err.code === "ERR_ASSERTION";
+        var status = isAssertionError ? "failed" : "broken";
         if(global.onError) {
             global.onError(err);
         }

--- a/test/fixtures/assert.spec.js
+++ b/test/fixtures/assert.spec.js
@@ -1,0 +1,13 @@
+/*eslint-env mocha*/
+"use strict";
+var assert = require("assert");
+
+describe("Tests using assert", function() {
+    it("passing test", function() {
+        assert.ok(true);
+    });
+
+    it("failed test", function() {
+        assert.ok(false);
+    });
+});

--- a/test/unit/reporter.spec.js
+++ b/test/unit/reporter.spec.js
@@ -1,6 +1,7 @@
 var path = require("path");
 var Mocha = require("mocha");
 var mockery = require("mockery");
+var AssertionError = require("assert").AssertionError;
 var chai = require("chai");
 var sinon = require("sinon");
 var sinonChai = require("sinon-chai");
@@ -103,6 +104,24 @@ describe("Allure reporter", function() {
             expect(allureMock.endCase).to.have.been.calledTwice;
 
             expect(status).to.be.equal(1);
+            done();
+        });
+    });
+    it("should handle tests using native node module 'assert'", function(done) {
+        var mocha = new Mocha({
+            reporter: reporter
+        });
+        mocha.addFile(path.join(__dirname, "../fixtures/assert.spec.js"));
+        mocha.run(function() {
+            expect(allureMock.startCase).callCount(2);
+            expect(allureMock.endCase).callCount(2);
+
+            expect(allureMock.startCase.firstCall).calledWithExactly("passing test");
+            expect(allureMock.endCase.firstCall).calledWith("passed");
+
+            expect(allureMock.startCase.secondCall).calledWithExactly("failed test");
+            expect(allureMock.endCase.secondCall).calledWith("failed", sinon.match.instanceOf(AssertionError));
+
             done();
         });
     });


### PR DESCRIPTION
NodeJS 8 (and above) has different name for AssertionError class. The recommended way is [to use error code](https://nodejs.org/docs/latest-v10.x/api/assert.html#assert_new_assert_assertionerror_options).